### PR TITLE
Exclude false positives from pair results.

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,18 +18,21 @@ function search(x, dims, r) {
             ((m[3] ? parseFloat(m[3]) / 3600 : 0))) *
             ((m[4] && m[4] === 'S' || m[4] === 'W') ? -1 : 1),
         regex: r,
+        raw: m[0],
         dim: m[4]
     };
 }
 
 function pair(x, dims) {
+    x = x.trim();
     var one = search(x, dims);
     if (one.val === null) return null;
     var two = search(x, dims, one.regex);
-    if (one.val !== null && two.val !== null) {
-        if (one.dim) return swapdim(one.val, two.val, one.dim);
-        else return [one.val, two.val];
-    }
+    if (two.val === null) return null;
+    // null if one/two are not contiguous.
+    if (one.raw + two.raw !== x) return null;
+    if (one.dim) return swapdim(one.val, two.val, one.dim);
+    else return [one.val, two.val];
 }
 
 function swapdim(a, b, dim) {

--- a/test/sexagesimal.js
+++ b/test/sexagesimal.js
@@ -44,6 +44,13 @@ describe('sexagesimal', function() {
             expect(sexagesimal.pair('32W 66S')).to.eql([-66, -32]);
             expect(sexagesimal.pair('32W, 66S')).to.eql([-66, -32]);
             expect(sexagesimal.pair('66° 30′ 360″ N, 66° 30′ 720" W')).to.eql([66.6, -66.7]);
+            expect(sexagesimal.pair('32W, 66S ')).to.eql([-66, -32]);
+        });
+        it('returns null for non sexagesimal strings', function() {
+            expect(sexagesimal.pair('32W, 66S cruft')).to.eql(null);
+            expect(sexagesimal.pair('500 johnson st 11310')).to.eql(null);
+            expect(sexagesimal.pair('500 5th')).to.eql(null);
+            expect(sexagesimal.pair('500 5th st nw')).to.eql(null);
         });
     });
 


### PR DESCRIPTION
Adds tests for the following input and ensures they aren't considered pairs.

> 32W, 66S cruft
> 500 johnson st 11310
> 500 5th
> 500 5th st nw

cc @tmcw pls review
