### PR TITLE
Interpret (º˚) symbols commonly confused for degree symbol

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ function search(x, dims, r) {
   if (!dims) dims = 'NSEW';
   if (typeof x !== 'string') return { val: null, regex: r };
 
-  r = r || /[\s\,]*([NSEW])?\s*([\-|\—|\―]?[0-9.]+)°?\s*(?:([0-9.]+)['’′‘]\s*)?(?:([0-9.]+)(?:''|"|”|″)\s*)?([NSEW])?/gi;
+  r = r || /[\s\,]*([NSEW])?\s*([\-|\—|\―]?[0-9.]+)[°º˚]?\s*(?:([0-9.]+)['’′‘]\s*)?(?:([0-9.]+)(?:''|"|”|″)\s*)?([NSEW])?/gi;
 
   var m = r.exec(x);
   if (!m) return { val: null, regex: r };

--- a/test/parse.js
+++ b/test/parse.js
@@ -4,6 +4,8 @@ var sexagesimal = require('../'),
 test('basic directions with degrees', function(t) {
     t.deepEqual(sexagesimal('0° N'), 0);
     t.deepEqual(sexagesimal('66° N'), 66);
+    t.deepEqual(sexagesimal('66º N'), 66);
+    t.deepEqual(sexagesimal('66˚ N'), 66);
     t.deepEqual(sexagesimal('66.5° N'), 66.5);
     t.deepEqual(sexagesimal('66.2525° N'), 66.2525);
     t.deepEqual(sexagesimal('66° S'), -66);


### PR DESCRIPTION
As mentioned here: https://en.wikipedia.org/wiki/Degree_symbol

I used to use the ordinal symbol for degrees all the time before I knew the difference.