### PR TITLE
Fix issue where values prefixed with a vertical pipe wouldn't properly return null

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,7 +49,7 @@ function search(input, dims) {
   if (typeof input !== 'string') return null;
 
   input = input.toUpperCase();
-  var regex = /^[\s\,]*([NSEW])?\s*([\-|\—|\―]?[0-9.]+)[°º˚]?\s*(?:([0-9.]+)['’′‘]\s*)?(?:([0-9.]+)(?:''|"|”|″)\s*)?([NSEW])?/;
+  var regex = /^[\s\,]*([NSEW])?\s*([\-\—\―]?[0-9.]+)[°º˚]?\s*(?:([0-9.]+)['’′‘]\s*)?(?:([0-9.]+)(?:''|"|”|″)\s*)?([NSEW])?/;
 
   var m = input.match(regex);
   if (!m) return null;  // no match

--- a/test/pair.js
+++ b/test/pair.js
@@ -55,6 +55,7 @@ test('leading dimension, comma separator', function(t) {
 });
 
 test('returns null for non sexagesimal strings', function(t) {
+    t.deepEqual(sexagesimal.pair('|32, |66'), null);
     t.deepEqual(sexagesimal.pair('W32, S66 cruft'), null);
     t.deepEqual(sexagesimal.pair('cruft W32, S66'), null);
     t.deepEqual(sexagesimal.pair('cruft W32, S66 cruft'), null);


### PR DESCRIPTION
The regex for the minus sign was `[\-|\—|\―]`, where the vertical pipe was intended as an "or" operator, but was actually included in the character set. This meant garbage inputs like `|32.23, |66.90` were erroneously accepted.